### PR TITLE
Modifying pyproject to avoid exporting PYTHONPATH

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,7 +16,6 @@ jobs:
         pip install coverage coveralls
     - name: Test with pytest
       run: |
-        export PYTHONPATH=./src
         python -m coverage run -m pytest -sv
     - name: Submit to coveralls
       continue-on-error: true
@@ -26,7 +25,6 @@ jobs:
         coveralls --service=github
     - name: Test with nomad
       run: |
-        export PYTHONPATH=./src
         python -m nomad.cli parse tests/data/test.archive.yaml
   build-and-install:
     runs-on: ubuntu-latest
@@ -46,7 +44,6 @@ jobs:
         pip install dist/*.tar.gz --index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
     - name: Test with nomad
       run: |
-        export PYTHONPATH=./src
         python -m nomad.cli parse tests/data/test.archive.yaml
   ruff-linting:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,30 +5,35 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = 'nomad-analysis'
-version = '1.0'
-description = 'A standard NOMAD plugin for analysis.'
+name = "nomad-analysis"
+version = '0.1.0'
+description = "A standard NOMAD plugin for analysis."
 readme = "README.md"
 authors = [
     { name = "Sarthak Kapoor", email = "sarthak.kapoor@physik.hu-berlin.de" }
 ]
 license = { text = "Apache-2.0" }
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "License :: OSI Approved :: Apache Software License",
+]
 dependencies = [
     "nomad-lab>=1.2.2dev399",
     "nbformat>=5.9.2",
-    "importlib-metadata~=4.13.0",
+]
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.2.0",
+    "pytest",
+    "structlog==22.3.0"
 ]
 
 [project.urls]
 "Homepage" = "https://github.com/FAIRmat-NFDI/nomad-analysis"
 "Bug Tracker" = "https://github.com/FAIRmat-NFDI/nomad-analysis/issues"
-
-[project.optional-dependencies]
-dev = [
-    'ruff>=0.2.0',
-    'pytest',
-    'structlog==22.3.0'
-]
     
 [tool.ruff]   
 # Exclude a variety of commonly ignored directories.
@@ -105,4 +110,4 @@ line-ending = "auto"
 where = ["src"]
 
 [tool.setuptools.package-data]
-nomadschemaexample = ['*/nomad_plugin.yaml']
+nomad_analysis = ['*/nomad_plugin.yaml']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ line-ending = "auto"
 
 
 [tool.setuptools.packages.find]
-include = ["src"]
+where = ["src"]
 
 [tool.setuptools.package-data]
 nomadschemaexample = ['*/nomad_plugin.yaml']


### PR DESCRIPTION
Changing this
```yaml
[tool.setuptools.packages.find]
include = ["src"]
```
to
```yaml
[tool.setuptools.packages.find]
where = ["src"]
```
allows to run pytests in the workflow without explicitly exporting the `src` directory to PYTHONPATH. This way the tests run on the installed package rather than the source code. 

From discussions with @hampusnasstrom 