### PR TITLE
7 add pytest fixture to extract logs of normalize for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
 dev = [
     "ruff>=0.2.0",
     "pytest",
-    "structlog==22.3.0"
+    "structlog==22.3.0",
+    "python-logstash",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "nomad-lab>=1.2.2dev399",
+    "nomad-lab>=1.2.2dev457",
     "nbformat>=5.9.2",
 ]
 [project.optional-dependencies]

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -32,6 +32,7 @@ Upcoming features:
 - Link the output section of the analysis schema to a sub-section of the input.
 - Write the analysis results back to the output section.
 """
+
 import json
 import os
 from typing import TYPE_CHECKING

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -151,6 +151,7 @@ class ELNJupyterAnalysis(JupyterAnalysis):
     )
     analysis_type = Quantity(
         type=str,
+        default='Generic',
         description=(
             'Based on the analysis type, code cells will be added to the Jupyter '
             'notebook. Code cells from **Generic** are always included.'
@@ -204,8 +205,8 @@ class ELNJupyterAnalysis(JupyterAnalysis):
         """
         if self.name:
             file_name = (
-                self.name.replace(' ', '_')
-                + f'_{self.analysis_type.lower()}_notebook.ipynb'
+                self.name.replace(' ', '_') + '_' +
+                self.analysis_type.lower() + '_notebook.ipynb'
             )
         else:
             file_name = 'untitled.ipynb'
@@ -397,7 +398,6 @@ class ELNGenericJupyterAnalysis(ELNJupyterAnalysis, EntryData):
     )
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
-        self.analysis_type = 'Generic'
         super().normalize(archive, logger)
 
 

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -201,13 +201,19 @@ class ELNJupyterAnalysis(JupyterAnalysis):
             archive (EntryArchive): The archive containing the section.
             logger (BoundLogger): A structlog logger.
         """
-        file_name = (
-            self.name.replace(' ', '_')
-            + f'_{self.analysis_type.lower()}_notebook.ipynb'
-        )
-        if not archive.m_context.raw_path_exists(self.notebook):
+        if self.name:
+            file_name = (
+                self.name.replace(' ', '_')
+                + f'_{self.analysis_type.lower()}_notebook.ipynb'
+            )
+        else:
+            file_name = 'untitled.ipynb'
+
+        if self.notebook is None:
             self.notebook = file_name
-        elif not self.notebook == file_name:
+            return
+
+        if self.notebook != file_name:
             raw_path = archive.m_context.raw_path()
             os.rename(
                 os.path.join(raw_path, self.notebook),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
+import glob
 import json
+import os
 
 import pytest
 from nomad.utils import structlogging
 
 
 @pytest.fixture(scope='function')
-def extract_from_logger(caplog):
+def capture_from_logger(caplog):
     '''
     Extracts log messages from the logger and raises an assertion error if any
     ERROR messages are found.
@@ -19,3 +21,20 @@ def extract_from_logger(caplog):
             except Exception:
                 msg = record.msg
             assert False, msg
+
+@pytest.fixture(scope='function')
+def clean_up():
+    '''
+    Deletes all files created during the test.
+    '''
+    yield
+    # add file extensions as wildcard for clean up
+    file_types = ['*.ipynb']
+    generated_files = []
+    for file_type in file_types:
+        generated_files = glob.glob(os.path.join(
+            os.path.dirname(__file__), 'data', file_type)
+        )
+    for file in generated_files:
+        os.remove(file)
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import json
+
+import pytest
+from nomad.utils import structlogging
+
+
+@pytest.fixture(scope='function')
+def extract_from_logger(caplog):
+    '''
+    Extracts log messages from the logger and raises an assertion error if any
+    ERROR messages are found.
+    '''
+    caplog.handler.formatter = structlogging.ConsoleFormatter()
+    yield caplog
+    for record in caplog.get_records(when='call'):
+        if record.levelname in ['ERROR']:
+            try:
+                msg = structlogging.ConsoleFormatter.serialize(json.loads(record.msg))
+            except Exception:
+                msg = record.msg
+            assert False, msg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,10 @@ from nomad.utils import structlogging
 
 @pytest.fixture(scope='function')
 def capture_from_logger(caplog):
-    '''
+    """
     Extracts log messages from the logger and raises an assertion error if any
     ERROR messages are found.
-    '''
+    """
     caplog.handler.formatter = structlogging.ConsoleFormatter()
     yield caplog
     for record in caplog.get_records(when='call'):
@@ -22,19 +22,19 @@ def capture_from_logger(caplog):
                 msg = record.msg
             assert False, msg
 
+
 @pytest.fixture(scope='function')
 def clean_up():
-    '''
+    """
     Deletes all files created during the test.
-    '''
+    """
     yield
     # add file extensions as wildcard for clean up
     file_types = ['*.ipynb']
     generated_files = []
     for file_type in file_types:
-        generated_files = glob.glob(os.path.join(
-            os.path.dirname(__file__), 'data', file_type)
+        generated_files = glob.glob(
+            os.path.join(os.path.dirname(__file__), 'data', file_type)
         )
     for file in generated_files:
         os.remove(file)
-    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from nomad.utils import structlogging
 
 
 @pytest.fixture(scope='function')
-def capture_from_logger(caplog):
+def capture_error_from_logger(caplog):
     """
     Extracts log messages from the logger and raises an assertion error if any
     ERROR messages are found.

--- a/tests/data/test.archive.yaml
+++ b/tests/data/test.archive.yaml
@@ -1,3 +1,2 @@
 data:
   m_def: nomad_analysis.ELNJupyterAnalysis
-  analysis_type: test

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,3 +9,4 @@ def test_schema(capture_from_logger, clean_up):
     normalize_all(entry_archive)
 
     assert entry_archive.data.analysis_type == 'test'
+    # TODO: Add tests for generated jupyter notebook

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,10 +3,10 @@ import os.path
 from nomad.client import normalize_all, parse
 
 
-def test_schema(capture_from_logger, clean_up):
+def test_schema(capture_error_from_logger, clean_up):
     test_file = os.path.join(os.path.dirname(__file__), 'data', 'test.archive.yaml')
     entry_archive = parse(test_file)[0]
     normalize_all(entry_archive)
 
-    assert entry_archive.data.analysis_type == 'test'
+    assert entry_archive.data.analysis_type == 'Generic'
     # TODO: Add tests for generated jupyter notebook

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,7 +3,7 @@ import os.path
 from nomad.client import normalize_all, parse
 
 
-def test_schema():
+def test_schema(extract_from_logger):
     test_file = os.path.join(os.path.dirname(__file__), 'data', 'test.archive.yaml')
     entry_archive = parse(test_file)[0]
     normalize_all(entry_archive)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,7 +3,7 @@ import os.path
 from nomad.client import normalize_all, parse
 
 
-def test_schema(extract_from_logger):
+def test_schema(capture_from_logger, clean_up):
     test_file = os.path.join(os.path.dirname(__file__), 'data', 'test.archive.yaml')
     entry_archive = parse(test_file)[0]
     normalize_all(entry_archive)


### PR DESCRIPTION
- [x] Add logstash as dev dependency needed to use the nomad logger object
- [x] Add fixtures (capture log and clean up)
- [x] Adjust schema method to work with ClientContext when testing without a server
- [x] Add todo for adding tests for generated jupyter notebook
- [x] Merge the required changes to ClientContext in gitlab nomad-FAIR https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1711