### PR TITLE
8 refer all entries belonging to a certain class

### DIFF
--- a/nomad.yaml
+++ b/nomad.yaml
@@ -10,3 +10,5 @@ plugins:
   options:
     schemas/nomad_analysis:
       python_package: nomad_analysis
+  exclude:
+    - 'parsers/nexus'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,12 @@ dev = [
     "ruff>=0.2.0",
     "pytest",
     "structlog==22.3.0",
-    "python-logstash",
+    "python-logstash==0.4.6",
+    "mongoengine>=0.20",
+    "pyjwt[crypto]==2.6.0",
+    "unidecode==1.3.2",
+    "fastapi==0.92.0",
+    "zipstream-new==1.1.5",
 ]
 
 [project.urls]

--- a/src/nomad_analysis/analysis_source.py
+++ b/src/nomad_analysis/analysis_source.py
@@ -1,19 +1,20 @@
 """
-    Contains analysis functions which will be included in the Jupyter analysis notebook.
+Contains analysis functions which will be included in the Jupyter analysis notebook.
 
-    The functions should be added along its category using the `category` decorator. The
-    category should be correspond to `analysis_type` in the schema.
+The functions should be added along its category using the `category` decorator. The
+category should be correspond to `analysis_type` in the schema.
 
-    At present, the experiment specific categories includes `XRD`.
-    For e.g., when adding an analysis function for XRD, use `@category('XRD')` 
-    decorator.
+At present, the experiment specific categories includes `XRD`.
+For e.g., when adding an analysis function for XRD, use `@category('XRD')`
+decorator.
 
-    Use `@category('Generic')` for functions which should always be included.
+Use `@category('Generic')` for functions which should always be included.
 
-    Important:
-        Necessary library or module imports should be included inside the function.
-        This will allow the imports to be specified in the generated Jupyter notebook.
+Important:
+    Necessary library or module imports should be included inside the function.
+    This will allow the imports to be specified in the generated Jupyter notebook.
 """
+
 from nomad_analysis.utils import category
 
 

--- a/src/nomad_analysis/analysis_source.py
+++ b/src/nomad_analysis/analysis_source.py
@@ -66,6 +66,14 @@ def get_input_data(token_header: dict, base_url: str, analysis_entry_id: str) ->
     for entry in referred_entries:
         entry_ids.append(entry_id_from_reference(entry['reference']))
 
+    query = {
+        'required': {
+            'data': '*',
+            'workflow2': '*',
+            'metadata': '*',
+            'results': '*',
+        }
+    }
     entry_archive_data_list = []
     for entry_id in entry_ids:
         response = requests.post(

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -46,7 +46,6 @@ from nomad.datamodel.metainfo.annotations import (
     BrowserAnnotation,
     ELNAnnotation,
     ELNComponentEnum,
-    SectionProperties,
 )
 from nomad.datamodel.metainfo.basesections import (
     Analysis,
@@ -512,6 +511,21 @@ class ELNGenericJupyterAnalysis(ELNJupyterAnalysis, EntryData):
     m_def = Section(
         categories=[JupyterAnalysisCategory],
         label='Generic Jupyter Notebook Analysis',
+        a_eln=ELNAnnotation(
+            properties={
+                'order': [
+                    'name',
+                    'datetime',
+                    'lab_id',
+                    'location',
+                    'description',
+                    'analysis_type',
+                    'notebook',
+                    'reset_notebook',
+                    'input_entry_class',
+                ],
+            },
+        ),
     )
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
@@ -526,6 +540,21 @@ class ELNXRDJupyterAnalysis(ELNJupyterAnalysis, EntryData):
     m_def = Section(
         categories=[JupyterAnalysisCategory],
         label='XRD Jupyter Notebook Analysis',
+        a_eln=ELNAnnotation(
+            properties={
+                'order': [
+                    'name',
+                    'datetime',
+                    'lab_id',
+                    'location',
+                    'description',
+                    'analysis_type',
+                    'notebook',
+                    'reset_notebook',
+                    'input_entry_class',
+                ],
+            },
+        ),
     )
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -302,7 +302,9 @@ class ELNJupyterAnalysis(JupyterAnalysis):
             return
         for entry in search_result.data:
             ref = {
-                'm_proxy_value': f'../uploads/{entry["upload_id"]}/raw/{entry["entry_name"]}#/data',
+                'm_proxy_value': (
+                    f'../uploads/{entry["upload_id"]}/raw/{entry["entry_name"]}#/data'
+                ),
                 'lab_id': self.get_lab_id(
                     f'../uploads/{entry["upload_id"]}/raw/{entry["entry_name"]}#/data',
                     entry['upload_id'],

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -301,12 +301,12 @@ class ELNJupyterAnalysis(JupyterAnalysis):
         if not search_result.data:
             return
         for entry in search_result.data:
+            entry_id = entry['entry_id']
+            upload_id = entry['upload_id']
             ref = {
-                'm_proxy_value': (
-                    f'../uploads/{entry["upload_id"]}/raw/{entry["entry_name"]}#/data'
-                ),
+                'm_proxy_value': f'../uploads/{upload_id}/archive/{entry_id}#/data',
                 'lab_id': self.get_lab_id(
-                    f'../uploads/{entry["upload_id"]}/raw/{entry["entry_name"]}#/data',
+                    f'../uploads/{upload_id}/archive/{entry_id}#/data',
                     entry['upload_id'],
                     archive,
                     logger,

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -214,8 +214,10 @@ class ELNJupyterAnalysis(JupyterAnalysis):
         """
         if self.name:
             file_name = (
-                self.name.replace(' ', '_') + '_' +
-                self.analysis_type.lower() + '_notebook.ipynb'
+                self.name.replace(' ', '_')
+                + '_'
+                + self.analysis_type.lower()
+                + '_notebook.ipynb'
             )
         else:
             file_name = 'untitled.ipynb'


### PR DESCRIPTION
- Adds a quantity `input_entry_class` which is `StringEditQuantity`
- Based on the quantity, a search is implemented to find all the inputs that the user can see which belong to the specified entry class
- Search results are then added to the inputs section as section references
- Care is taken to avoid duplication of inputs
  - if m_proxy_value is repeated
  - if lab_id is repeated (in case lab_id is None, this check is ignored)
  

> Note: Currently, the lab_id is not available in the resolved references as the normalize methods are not run. This needs to be fixed in future.