### PR TITLE
23 lab id in inputs name

### DIFF
--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -319,6 +319,8 @@ class ELNJupyterAnalysis(JupyterAnalysis):
                 'name': resolved_section.get('name'),
                 'lab_id': resolved_section.get('lab_id'),
             }
+            if resolved_section.get('lab_id') is not None:
+                ref['name'] = resolved_section.get('lab_id')
             ref_list.append(ref)
         return ref_list
 

--- a/src/nomad_analysis/schema.py
+++ b/src/nomad_analysis/schema.py
@@ -338,6 +338,18 @@ class ELNJupyterAnalysis(JupyterAnalysis):
         for m_proxy_value in ref_hash_map:
             self.inputs.append(SectionReference(reference=m_proxy_value))
 
+    def set_name_for_inputs(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+        """
+        Set the name of the input references based on the lab_id or name of the referenced
+        section. If lab_id, it is preferred over the name. If both are not available, the
+        reference name remains the default: None.
+        """
+        for input_ref in self.inputs:
+            if input_ref.reference.get('lab_id') is not None:
+                input_ref.name = input_ref.reference.lab_id
+            elif input_ref.reference.get('name') is not None:
+                input_ref.name = input_ref.reference.name
+
     def write_predefined_cells(
         self, archive: 'EntryArchive', logger: 'BoundLogger'
     ) -> list:
@@ -497,6 +509,7 @@ class ELNJupyterAnalysis(JupyterAnalysis):
 
         self.set_jupyter_notebook_name(archive, logger)
         self.get_inputs_from_entry_class(archive, logger)
+        self.set_name_for_inputs(archive, logger)
 
         if self.reset_notebook:
             self.write_jupyter_notebook(archive, logger)


### PR DESCRIPTION
In addition to setting inputs name, PR also improves the filtering and code structure. 

- [x] Make a separate method for resolving references: `get_resolved_section`
- [x] Use `get_resolved_section` when making new SectionReferences based on "Input Entry Class"
- [x] Define the `reset_input_references` method, which is used in the normalize method of ELN class, and combines the following functions:
  - [x] Get the existing references and create new references based on the "Input Entry Class"
  - [x] normalize m_proxy_value to be of consistent form `<entry>/#<section>` 
  - [x] Filter out the repeated references based on lab_id and m_proxy_value
- [x] Name the input reference based on the lab-id or name (lab-id preferred over name) of the referenced section
  - [x] Only if the name is None, it will be set by this method. If the name already exists (for example, added by the user), it will not be modified   