### PR TITLE
Refactor input references

### DIFF
--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -215,7 +215,6 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
         ),
         default=True,
         a_eln=ELNAnnotation(
-            label='Reset pre-defined cells in Notebook',
             component=ELNComponentEnum.BoolEditQuantity,
         ),
     )
@@ -223,7 +222,6 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
         type=str,
         description='Generated Jupyter notebook file.',
         a_eln=ELNAnnotation(
-            label='Jupyter Notebook',
             component=ELNComponentEnum.FileEditQuantity,
         ),
         a_browser=BrowserAnnotation(adaptor='RawFileAdaptor'),
@@ -232,7 +230,6 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
         type=Query,
         description='Query to get the input entries for the analysis.',
         a_eln=ELNAnnotation(
-            label='Query for Inputs',
             component=ELNComponentEnum.QueryEditQuantity,
             props=dict(
                 storeInArchive=True,
@@ -244,11 +241,10 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
     input_entry_class = Quantity(
         type=str,
         description="""
-        (Deprecated in favor of `query_for_inputs`)
         Reference all the available entries of this EntryClass as inputs.
+        (Deprecated in favor of `query_for_inputs`)
         """,
         a_eln=ELNAnnotation(
-            label='Input Entry Class',
             component=ELNComponentEnum.StringEditQuantity,
         ),
     )

--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -424,13 +424,15 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
             if input_ref.reference is None:
                 continue
             ref = ReferencedEntry(
-                m_proxy_value=normalize_m_proxy_value(
-                    input_ref.reference.m_proxy_value
-                ),
+                m_proxy_value=input_ref.reference.m_proxy_value,
                 name=input_ref.name,
                 lab_id=input_ref.reference.get('lab_id'),
             )
             ref_list.append(ref)
+
+        # normalize m_proxy_value
+        for ref in ref_list:
+            ref.m_proxy_value = normalize_m_proxy_value(ref.m_proxy_value)
 
         # filter based on m_proxy_value, and lab_id (if available)
         ref_hash_map = {}


### PR DESCRIPTION
- `normalize_input_references` method is more general now. It takes a list of references as an argument, which can be collected based on search queries or references of newly generated archives. This list is combined with the list of references coming from the QueryEditQuantity in the ELN. The references are merged, filtering out duplicates.
- `input_entry_class` has been deprecated in favor of the `query_for_inputs` quantity.