### PR TITLE
Updating and commenting out nomad-infra deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "nbformat>=5.9.2",
 ]
 [project.urls]
-Repository = "https://github.com/ka-sarthak/nomad-analysis"
+Repository = "https://github.com/FAIRmat-NFDI/nomad-analysis"
 Documentation = "https://fairmat-nfdi.github.io/nomad-analysis/"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dev = [
     "pytest",
     "structlog",
     "python-logstash==0.4.6",
-    "mongoengine>=0.20",
-    "pyjwt[crypto]==2.6.0",
-    "unidecode==1.3.2",
-    "fastapi==0.92.0",
-    "zipstream-new==1.1.5",
+    # "mongoengine>=0.4",
+    # "pyjwt[crypto]==2.6.0",
+    # "unidecode=1.3.2",
+    # "fastapi<0.100",
+    # "zipstream-new==1.1.5",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Documentation = "https://fairmat-nfdi.github.io/nomad-analysis/"
 [project.optional-dependencies]
 dev = [
     "ruff",
-    "pytest",
+    "pytest>=5.0",
     "structlog",
     "python-logstash==0.4.6",
     # "mongoengine>=0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "ruff",
     "pytest>=5.0",
     "structlog",
-    "python-logstash==0.4.6",
+    "python-logstash>=0.4.6",
     # "mongoengine>=0.4",
     # "pyjwt[crypto]==2.6.0",
     # "unidecode=1.3.2",


### PR DESCRIPTION
NOMAD infrastructure deps are required for the pytest fixture to capture log from logger. While implementing the fixture, these deps were required.
```toml
"python-logstash==0.4.6",
"mongoengine>=0.20",
"pyjwt[crypto]==2.6.0",
"unidecode==1.3.2",
"fastapi==0.92.0",
"zipstream-new==1.1.5",
```

As of today, only `python-logstash` is required.

In this, I am updating the entire list to match the versions in https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/blob/develop/pyproject.toml?ref_type=heads#L72

and commenting out the deps that are no longer needed.
