### PR TITLE
Changed create_entry_with_api to not create EntryArchive instance

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -43,13 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
-          args: "format . --check"
+          args: "format --check"
   ruff-linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
-          args: "check ."
+          args: "check"

--- a/src/nomad_analysis/analysis_source.py
+++ b/src/nomad_analysis/analysis_source.py
@@ -67,8 +67,7 @@ def get_analysis_entry(entry_id: str, url: str = None):
 
     if not entry_list:
         print(
-            f'Analysis entry with id "{entry_id}" not '
-            f'found at the given URL "{url}".'
+            f'Analysis entry with id "{entry_id}" not found at the given URL "{url}".'
         )
         return None
     if len(entry_list) > 1:
@@ -303,8 +302,7 @@ def xrd_voila_analysis(input_data) -> None:  # noqa: PLR0915
     )
 
     no_input_alert = widgets.HTML(
-        '<p style="color:red;">No input entry of class'
-        '`ELNXRayDiffraction` found.</p>'
+        '<p style="color:red;">No input entry of class`ELNXRayDiffraction` found.</p>'
     )
     no_input_alert.layout.visibility = 'hidden'
     no_peak_alert = widgets.HTML(

--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -515,11 +515,7 @@ class ELNJupyterAnalysis(JupyterAnalysis, EntryData):
             cells.append(nbf.v4.new_code_cell(source=comment + code))
 
         if self.analysis_type == 'XRD':
-            code = (
-                '# Pre-defined block\n'
-                '\n'
-                'xrd_voila_analysis(analysis.data.inputs)\n'
-            )
+            code = '# Pre-defined block\n\nxrd_voila_analysis(analysis.data.inputs)\n'
             cells.append(nbf.v4.new_code_cell(source=code))
 
         return cells

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -152,12 +152,14 @@ def create_entry_with_api(
         params['overwrite_if_exists'] = True
 
     if not isinstance(section, EntryArchive):
-        entry = EntryArchive(data=section)
+        json_dict = {
+            'data': section.m_to_dict(),
+        }
     else:
-        entry = section
+        json_dict = section.m_to_dict()
 
     response = put_nomad_request(
-        url=endpoint, json_dict=entry.m_to_dict(), params=params
+        url=endpoint, json_dict=json_dict, params=params
     )
 
     reference = get_reference(

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -158,9 +158,7 @@ def create_entry_with_api(
     else:
         json_dict = section.m_to_dict()
 
-    response = put_nomad_request(
-        url=endpoint, json_dict=json_dict, params=params
-    )
+    response = put_nomad_request(url=endpoint, json_dict=json_dict, params=params)
 
     reference = get_reference(
         upload_id=response['processing']['entry']['upload_id'],

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -158,7 +158,9 @@ def create_entry_with_api(
     else:
         json_dict = section.m_to_dict()
 
-    response = put_nomad_request(url=endpoint, json_dict=json_dict, params=params)
+    response = put_nomad_request(
+        url=endpoint, json_dict=json_dict, params=params
+    )
 
     reference = get_reference(
         upload_id=response['processing']['entry']['upload_id'],


### PR DESCRIPTION
In the `create_entry_with_api()` function in `utils.py` the creation of an `EntryArchive(data=section)` when the `section` was not an instance of `EntryArchive` was removing the `m_context` of a potential `EntryArchive` parent to the `section`. This could possibly have been solved by creating a deep copy of the section but calling `m_to_dict()` directly on the section and wrapping it in `{'data': section.m_to_dict()}` should also work as we are anyways just wanting to create a json dictionary of the `EntryArchive`. 