### PR TITLE
Return early if not server context

### DIFF
--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -19,6 +19,7 @@ import os
 from typing import TYPE_CHECKING, Union
 
 import nbformat as nbf
+from nomad.datamodel.context import ServerContext
 from nomad.datamodel.data import (
     EntryData,
     EntryDataCategory,
@@ -298,7 +299,8 @@ class JupyterAnalysis(Analysis, EntryData):
         """
         Combines the existing input references with references based on the
         `query_for_inputs` quantity. Filters out duplicates based on m_proxy_value and
-        lab_id. Sets the name of the input references.
+        lab_id. Sets the name of the input references. Returns without normalizing if
+        the context is not a server context.
         """
 
         def normalize_m_proxy_value(m_proxy_value):
@@ -319,6 +321,9 @@ class JupyterAnalysis(Analysis, EntryData):
                     f'Error in normalizing the m_proxy_value "{m_proxy_value}".\n{e}'
                 )
             return m_proxy_value
+
+        if not isinstance(archive.m_context, ServerContext):
+            return
 
         ref_list = []
         ref_list.extend(self.process_query_for_inputs(archive, logger))

--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -284,8 +284,8 @@ class JupyterAnalysis(Analysis, EntryData):
                 continue
             ref = ReferencedEntry(
                 m_proxy_value=resolved_entry.m_proxy_value,
-                name=resolved_entry.name,
-                lab_id=resolved_entry.lab_id,
+                name=resolved_entry.get('name'),
+                lab_id=resolved_entry.get('lab_id'),
             )
             ref_list.append(ref)
 
@@ -334,8 +334,8 @@ class JupyterAnalysis(Analysis, EntryData):
                 continue
             ref = ReferencedEntry(
                 m_proxy_value=input_ref.reference.m_proxy_value,
-                name=input_ref.reference.name,
-                lab_id=input_ref.reference.lab_id,
+                name=input_ref.reference.get('name'),
+                lab_id=input_ref.reference.get('lab_id'),
             )
             ref_list.append(ref)
 


### PR DESCRIPTION
 The `normalize_input_references` method is intended to work for `ServerContext` when the referenced sections in `JupyterAnalysis.inputs` are of type `MProxy` and have the attribute `m_proxy_value`. Even when these sections are resolved upon accessing, changing their class type from `MProxy` to `MSection`, they retain the `m_proxy_value` attribute.

However, if a section of type `MSection` is directly added to `data.inputs` programmatically (usually done when writing tests), i.e., without using `MProxy`, an attribute error will be raised when the `normalize_input_references` method tries to access `m_proxy_value` in the referenced section.

To avoid this, we can limit the `normalize_input_references` method to `ServerContext`, where the `ReferenceEditQuantity` ensures that an `MProxy` section is used when adding references.

- [x] Return without normalizing input references if not `ServerContext`.
- [x] Use `.get` to access `name` and `lab_id` to avoid attribute errors if the referenced `ArchiveSection` does not have these quantities.