### PR TITLE
68 create entry from api creates entries without m def

### DIFF
--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -490,7 +490,7 @@ class JupyterAnalysis(Analysis, EntryData):
             section=self,
             base_url=self.m_context.installation_url,
             upload_id=self.m_context.upload_id,
-            file_name=self.m_parent.metadata.entry_name,
+            file_name=self.m_parent.metadata.mainfile,
         )
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -197,7 +197,7 @@ def create_entry_with_api(
 
     if not isinstance(section, EntryArchive):
         json_dict = {
-            'data': section.m_to_dict(),
+            'data': section.m_to_dict(with_root_def=True),
         }
     else:
         json_dict = section.m_to_dict()


### PR DESCRIPTION
- `m_to_dict` adds the `m_def` by default when the `EntryData` section is wrapped with `EntryArchive`, and this is supplied to `create_entry_from_api`. If a standalone `EntryData` section is supplied instead, `with_root_def=True` needs to be specified in `m_to_dict`. 
- Fixed a bug where the `save` method used `entry_name` instead of `mainfile`.