### PR TITLE
Rename entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ where = ["src"]
 skip = [".github/*"]
 
 [project.entry-points.'nomad.plugin']
-general_analysis_schema = "nomad_analysis.general:schema"
-jupyter_analysis_schema = "nomad_analysis.jupyter:schema"
+general_analysis_schema = "nomad_analysis.general:schema_entry_point"
+jupyter_analysis_schema = "nomad_analysis.jupyter:schema_entry_point"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ select = [
 
 ignore = [
     "F403", # 'from module import *' used; unable to detect undefined names
+    "PLC0415", # `import` should be at the top-level of a file
 ]
 
 fixable = ["ALL"]

--- a/src/nomad_analysis/general/__init__.py
+++ b/src/nomad_analysis/general/__init__.py
@@ -26,7 +26,7 @@ class GeneralSchemaEntryPoint(SchemaPackageEntryPoint):
         return m_package
 
 
-schema = GeneralSchemaEntryPoint(
+schema_entry_point = GeneralSchemaEntryPoint(
     name='NOMADAnalysisGeneral',
     description='A module containing general schemas for analysis of FAIR data.',
 )

--- a/src/nomad_analysis/jupyter/__init__.py
+++ b/src/nomad_analysis/jupyter/__init__.py
@@ -27,7 +27,7 @@ class JupyterSchemaEntryPoint(SchemaPackageEntryPoint):
         return m_package
 
 
-schema = JupyterSchemaEntryPoint(
+schema_entry_point = JupyterSchemaEntryPoint(
     name='NOMADAnalysisJupyter',
     description='A module containing schemas for analysis using Jupyter notebooks.',
 )

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -151,12 +151,12 @@ def get_entry_data(
 
 def get_reference(upload_id: str, entry_id: str, archive_path: str = 'data') -> str:
     """
-    Returns the proxy value for referencing an entry.
+    Returns the proxy value for referencing a section of an entry.
 
     Args:
         upload_id (str): Upload ID of the upload in which the entry resides.
         entry_id (str): Entry ID of the entry.
-        archive_path (str): Path in the NOMAD upload where the entry is located.
+        archive_path (str): Path in the entry where the section is located.
             Defaults to 'data'.
 
     Returns:


### PR DESCRIPTION
- [x] Rename entry points to avoid confusion with between `nomad_analysis.*.schema` module and the entry point.
- [x] Remove the Ruff check for PLC0415: `import` should be at the top-level of a file 