### PR TITLE
Check action status before retrieving it

### DIFF
--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -102,6 +102,8 @@ class Action(ArchiveSection):
         Retrieves the status of the action using the action ID.
         """
         try:
+            if self.action_status == 'COMPLETED':
+                return
             if not self.action_instance_id:
                 raise ValueError('No action ID found.')
             status = manager.get_action_status(


### PR DESCRIPTION
If the status is completed, do not ping the Temporal server for the status. Since in most cases, Temporal logs are preserved for a limited time window (3 days on NOMAD servers), retrieving the status beyond that can lead to an error: `workflow_id` not found. This check avoids the case where the user tries to retrieve the status after it was recorded to be COMPLETED.