### PR TITLE
Use basesections from v2

### DIFF
--- a/src/nomad_analysis/general/schema.py
+++ b/src/nomad_analysis/general/schema.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-from nomad.datamodel.metainfo.basesections import (
+from nomad.datamodel.metainfo.basesections.v2 import (
     ActivityStep,
     Entity,
 )

--- a/src/nomad_analysis/jupyter/schema.py
+++ b/src/nomad_analysis/jupyter/schema.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.annotations import (
     ELNComponentEnum,
     SectionProperties,
 )
-from nomad.datamodel.metainfo.basesections import (
+from nomad.datamodel.metainfo.basesections.v2 import (
     Analysis,
     SectionReference,
 )


### PR DESCRIPTION
This pull request updates import statements in two schema files to reference the versioned module `basesections.v2` instead of the unversioned `basesections` (currently pointing to `basesections.v1`).

All changes are translational (changing the path of the module) while the functionality of v2 basesections is identical.

The `ActivityStep.comment` in `v1` is now `ActivityStep.description` in `v2`. 