### PR TITLE
Refactor Action base schemas

### DIFF
--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -305,6 +305,15 @@ class Action(ActionStatus, StopAction, StartAction):
     m_def = Section(
         description='Section for running NOMAD Actions.',
         categories=[ActionCategory],
+        a_display=SectionDisplayAnnotation(
+            order=[
+                'trigger_start_action',
+                'action_instance_id',
+                'action_status',
+                'trigger_get_action_status',
+                'trigger_stop_action',
+            ]
+        ),
     )
 
     @abstractmethod

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -165,28 +165,6 @@ class StartAction(ArchiveSection):
         """
         raise NotImplementedError('Subclasses should implement this method.')
 
-    # def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
-    #     """
-    #     Normalizes the action entry. If `trigger_start_action` is set to True, it calls
-    #     the `start_action` method to execute the action and sets
-    #     `trigger_get_action_status` to True to retrieve the action status. If
-    #     `trigger_get_action_status` is set to True, it calls the `_get_action_status`
-    #     method to update the `action_status`.
-
-    #     Args:
-    #         archive (Archive): A NOMAD archive.
-    #         logger (Logger): A structured logger.
-    #     """
-    #     if self.trigger_start_action:
-    #         try:
-    #             self.action_instance_id = self.start_action(archive, logger)
-    #         except Exception:
-    #             logger.warning('Failed to start the action.', exc_info=True)
-    #         finally:
-    #             self.trigger_start_action = False
-
-    #     super().normalize(archive, logger)
-
 
 class StopAction(ArchiveSection):
     """

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -15,14 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import json
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
 )
 
 from nomad.actions import manager
-from nomad.datamodel import ArchiveSection, EntryData
+from nomad.datamodel import ArchiveSection
 from nomad.datamodel.data import EntryDataCategory
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
@@ -36,8 +35,6 @@ from nomad.metainfo import (
     SchemaPackage,
     Section,
 )
-
-from nomad_analysis.utils import clean_rich_text_to_json
 
 if TYPE_CHECKING:
     from nomad.datamodel import EntryArchive
@@ -414,60 +411,6 @@ class Action(ActionStatus, StopAction, StartAction):
             self.get_action_status(self.action_instance_id, archive, logger)
 
         super().normalize(archive, logger)
-
-
-class ActionELN(Action, EntryData):
-    """
-    A general ELN section for running any NOMAD Action available in the deployment.
-    Built on top of the base `Action` class.
-
-    Users can start and monitor an action by specifying the `action_id` and
-    `action_input`.
-    """
-
-    m_def = Section(
-        description='ELN interface for running a NOMAD Action.',
-        a_display=SectionDisplayAnnotation(
-            order=[
-                'action_id',
-                'action_input',
-                'trigger_start_action',
-                'action_instance_id',
-                'action_status',
-                'trigger_get_action_status',
-                'trigger_stop_action',
-            ]
-        ),
-    )
-
-    action_id = Quantity(
-        type=str,
-        description='The action ID to be triggered. Should be in the format of '
-        '"namespace.package:action_name".',
-        a_eln=ELNAnnotation(component=ELNComponentEnum.StringEditQuantity),
-    )
-
-    action_input = Quantity(
-        type=str,
-        description='The input data for the action. Should be a JSON string that can '
-        'be parsed into the input data model of the given action.',
-        a_eln=ELNAnnotation(component=ELNComponentEnum.RichTextEditQuantity),
-    )
-
-    def start_action(self, archive, logger) -> str:
-        try:
-            clean_input = clean_rich_text_to_json(self.action_input)
-            action_input = json.loads(clean_input)
-            action_input_validated = manager.validate_action_arg(
-                self.action_id, action_input
-            )
-            instance_id = manager.start_action(
-                action_id=self.action_id,
-                data=action_input_validated,
-            )
-            return instance_id
-        except Exception as e:
-            logger.error(f'Failed to start the action: {e}', exc_info=True)
 
 
 m_package.__init_metainfo__()

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -127,27 +127,27 @@ class StartAction(ArchiveSection):
         """
         raise NotImplementedError('Subclasses should implement this method.')
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
-        """
-        Normalizes the action entry. If `trigger_start_action` is set to True, it calls
-        the `start_action` method to execute the action and sets
-        `trigger_get_action_status` to True to retrieve the action status. If
-        `trigger_get_action_status` is set to True, it calls the `_get_action_status`
-        method to update the `action_status`.
+    # def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+    #     """
+    #     Normalizes the action entry. If `trigger_start_action` is set to True, it calls
+    #     the `start_action` method to execute the action and sets
+    #     `trigger_get_action_status` to True to retrieve the action status. If
+    #     `trigger_get_action_status` is set to True, it calls the `_get_action_status`
+    #     method to update the `action_status`.
 
-        Args:
-            archive (Archive): A NOMAD archive.
-            logger (Logger): A structured logger.
-        """
-        if self.trigger_start_action:
-            try:
-                self.action_instance_id = self.start_action(archive, logger)
-            except Exception:
-                logger.warning('Failed to start the action.', exc_info=True)
-            finally:
-                self.trigger_start_action = False
+    #     Args:
+    #         archive (Archive): A NOMAD archive.
+    #         logger (Logger): A structured logger.
+    #     """
+    #     if self.trigger_start_action:
+    #         try:
+    #             self.action_instance_id = self.start_action(archive, logger)
+    #         except Exception:
+    #             logger.warning('Failed to start the action.', exc_info=True)
+    #         finally:
+    #             self.trigger_start_action = False
 
-        super().normalize(archive, logger)
+    #     super().normalize(archive, logger)
 
 
 class StopAction(ArchiveSection):
@@ -263,103 +263,56 @@ class ActionStatus(ArchiveSection):
             self.trigger_get_action_status = False
 
 
-
-class Action(ArchiveSection):
+class Action(ActionStatus, StopAction, StartAction):
     """
-    Base class for triggering actions from the ELN interface.
-    Subclasses should implement the `start_action` method.
+    Base class for actions that can be triggered from the ELN interface. Includes three
+    main functionalities: starting an action, stopping a running action, and retrieving
+    the status of an action.
+
+    Subclasses should implement the `start_action` method to define the specific action
+    to be performed.
     """
 
-    m_def = Section(description='Section for handling NOMAD Actions.')
-    action_instance_id = Quantity(
-        type=str,
-        description='The instance ID of the last triggered action.',
-    )
-    action_status = Quantity(
-        type=str,
-        description='The status of the action derived using the action instance ID.',
-    )
-    trigger_start_action = Quantity(
-        type=bool,
-        description='Starts the action defined under `start_action` method.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.ActionEditQuantity,
-            label='Run Action',
-        ),
-    )
-    trigger_get_action_status = Quantity(
-        type=bool,
-        description='Retrieves the status of the action using the action instance ID.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.ActionEditQuantity,
-            label='Get Action Status',
-        ),
-    )
-    trigger_stop_action = Quantity(
-        type=bool,
-        description='Stops the action using the action instance ID.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.ActionEditQuantity,
-            label='Stop Action',
-        ),
+    m_def = Section(
+        description='Section for running NOMAD Actions.',
+        categories=[ActionCategory],
     )
 
-    def start_action(self, archive, logger) -> str:
+    def start_action(self, archive, logger):
         """
         To be implemented by subclasses. Based on the data available in the ELN,
         use this method to prepare the input for the given action and trigger it using
-        `nomad.actions.manager.start_action`. The method should return the same instance
-        ID of the triggered action as returned by the
-        `nomad.actions.manager.start_action` method.
+        `nomad.actions.manager.start_action`.
+
+        The method should return the same instance ID of the triggered action as
+        returned by the `nomad.actions.manager.start_action` method.
+
+        Example implementation:
+
+        ```python
+        from nomad.actions import manager
+
+        def start_action(self, archive, logger) -> str:
+            # Prepare input for the action
+            action_input = MyActionInput(
+                user_id=archive.metadata.authors[0].user_id,
+                upload_id=archive.metadata.upload_id,
+                # other necessary input data for the action
+            )
+
+            # Start the action using the NOMAD action manager
+            instance_id = manager.start_action(
+                action_id='nomad_example.actions.myaction:my_action',
+                data=action_input,
+            )
+
+            return instance_id
+        ```
 
         Returns:
             str: The instance ID of the triggered action.
         """
         raise NotImplementedError('Subclasses should implement this method.')
-
-    def get_action_status(self, archive: 'EntryArchive', logger: 'BoundLogger'):
-        """
-        Retrieves the status of the action using the action instance ID.
-        """
-        try:
-            if self.action_status == 'COMPLETED':
-                return
-            if not self.action_instance_id:
-                raise ValueError('Action instance ID not provided.')
-            status = manager.get_action_status(
-                self.action_instance_id, archive.metadata.authors[0].user_id
-            )
-            self.action_status = status.name
-        except Exception:
-            logger.error(
-                'Failed to get status for action instance ID '
-                f'"{self.action_instance_id}".',
-                exc_info=True,
-            )
-        finally:
-            self.trigger_get_action_status = False
-
-    def stop_action(self, archive: 'EntryArchive', logger: 'BoundLogger'):
-        """
-        Stops the action using the action instance ID.
-        """
-        try:
-            if not self.action_instance_id:
-                raise ValueError('Action instance ID not provided.')
-            manager.stop_action(
-                self.action_instance_id, archive.metadata.authors[0].user_id
-            )
-        except Exception:
-            logger.error(
-                'Failed to stop the action with instance ID '
-                f'"{self.action_instance_id}".',
-                exc_info=True,
-            )
-        finally:
-            self.trigger_stop_action = False
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         """
@@ -394,7 +347,7 @@ class Action(ArchiveSection):
         """
         if self.action_status == 'RUNNING':
             # work with the latest status if last known status is RUNNING
-            self.get_action_status(archive, logger)
+            self.get_action_status(self.action_instance_id, archive, logger)
 
         if self.trigger_stop_action:
             if self.action_status != 'RUNNING':
@@ -404,7 +357,7 @@ class Action(ArchiveSection):
                     'is not running.'
                 )
             else:
-                self.stop_action(archive, logger)
+                self.stop_action(self.action_instance_id, archive, logger)
                 self.trigger_get_action_status = True
 
         if self.trigger_start_action:
@@ -424,7 +377,7 @@ class Action(ArchiveSection):
                     self.trigger_start_action = False
 
         if self.trigger_get_action_status:
-            self.get_action_status(archive, logger)
+            self.get_action_status(self.action_instance_id, archive, logger)
 
         super().normalize(archive, logger)
 

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -57,7 +57,7 @@ class ActionCategory(EntryDataCategory):
     Example usage:
 
     ```python
-    class MyActionELN(Action, EntryData):
+    class MyActionELN(StartAction, EntryData):
         m_def = Section(
             description='Section for running my custom action.',
             categories=[ActionCategory],
@@ -73,7 +73,39 @@ class ActionCategory(EntryDataCategory):
 
 
 class StartAction(ArchiveSection):
-    """Section to trigger an action instance."""
+    """
+    Section to trigger an action instance. Comes with an abstract method `start_action`
+    that should be implemented in the extended classes to provides the logic to trigger
+    an action.
+
+    ### Using `start_action` in normalize methods
+
+    Implementing `start_action` method alone will not trigger the action. How and when
+    it should be triggered needs to be defined in the `normalize` method of the child
+    section.
+
+    Here's an example that uses `trigger_start_action` quantity to trigger the action
+    when the quantity is set to True:
+
+    ```python
+    from nomad_analysis.actions.schema import StartAction
+
+
+    class MyExtendedStartAction(StartAction):
+        def start_action(self, archive, logger) -> str:
+            # Implement the logic to prepare the input for an action and start it.
+
+        def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+            super().normalize(archive, logger)
+            if self.trigger_start_action:
+                try:
+                    self.action_instance_id = self.start_action(archive, logger)
+                except Exception:
+                    logger.warning('Failed to start the action.', exc_info=True)
+                finally:
+                    self.trigger_start_action = False
+    ```
+    """
 
     action_instance_id = Quantity(
         type=str,
@@ -92,9 +124,11 @@ class StartAction(ArchiveSection):
 
     def start_action(self, archive, logger) -> str:
         """
-        To be implemented by subclasses. Based on the data available in the ELN,
-        use this method to prepare the input for the given action and trigger it using
-        `nomad.actions.manager.start_action`.
+        Provides the logic to trigger an action instance. To be implemented by
+        subclasses.
+
+        Based on the data available in the ELN, use this method to prepare the input
+        for the given action and trigger it using `nomad.actions.manager.start_action`.
 
         The method should return the same instance ID of the triggered action as
         returned by the `nomad.actions.manager.start_action` method.
@@ -103,28 +137,26 @@ class StartAction(ArchiveSection):
 
         ```python
         from nomad.actions import manager
+        from nomad_analysis.actions.schema import StartAction
 
-        def start_action(self, archive, logger) -> str:
-            # Prepare input for the action
-            action_input = MyActionInput(
-                user_id=archive.metadata.authors[0].user_id,
-                upload_id=archive.metadata.upload_id,
-                # other necessary input data for the action
-            )
 
-            # Start the action using the NOMAD action manager
-            instance_id = manager.start_action(
-                action_id='nomad_example.actions.myaction:my_action',
-                data=action_input,
-            )
+        class MyExtendedStartAction(StartAction):
+            def start_action(self, archive, logger) -> str:
+                # Prepare input for the action
+                action_input = MyActionInput(
+                    user_id=archive.metadata.authors[0].user_id,
+                    upload_id=archive.metadata.upload_id,
+                    # other necessary input data for the action
+                )
 
-            return instance_id
+                # Start the action using the NOMAD action manager
+                instance_id = manager.start_action(
+                    action_id='nomad_example.actions.myaction:my_action',
+                    data=action_input,
+                )
+
+                return instance_id
         ```
-
-        When using an implemented `start_action` method, condition it on the
-        `trigger_start_action` quantity to ensure that the action is triggered when the
-        quantity is set to True. And set the trigger quantity to False the method
-        is executed to avoid retriggering the action on the next normalization.
 
         Returns:
             str: The instance ID of the triggered action.
@@ -157,13 +189,20 @@ class StartAction(ArchiveSection):
 class StopAction(ArchiveSection):
     """
     Section to stop a running action instance. Comes with a method `stop_action` that
-    takes in action instance ID and schedules a cancellation of the action. It can used
-    in the `normalize` method of child sections and set to be triggered using the
-    `trigger_stop_action` quantity.
+    takes in action instance ID and schedules a cancellation of the action.
 
-    Example usage:
+    ### Using `stop_action` in normalize methods
+
+    How and when the `stop_action` method is triggered needs to be defined in the
+    `normalize` method of child sections.
+
+    Here's an example that uses `trigger_stop_action` quantity to trigger the action:
+
     ```python
-    class MyActionELN(..., StopAction):
+    from nomad_analysis.actions.schema import StopAction
+
+
+    class MyExtendedStopAction(..., StopAction):
         # Assuming quantity `action_instance_id` is already a property of the section.
         # Can be defined in the section or inherited from the parent section.
 
@@ -210,13 +249,21 @@ class StopAction(ArchiveSection):
 class ActionStatus(ArchiveSection):
     """
     Section to save and fetch the status of an action instance. Comes with a method
-    `get_action_status` that takes in action instance ID and gets the status. It can
-    used in the `normalize` method of child sections and set to be triggered using
-    the `trigger_get_action_status` quantity.
+    `get_action_status` that takes in action instance ID and gets the status.
+
+    ### Using `get_action_status` in normalize methods
+    How and when the `get_action_status` method is triggered needs to be defined in the
+    `normalize` method of child sections.
+
+    Here's an example that uses `trigger_get_action_status` quantity to trigger the
+    action status retrieval:
 
     Example usage:
 
     ```python
+    from nomad_analysis.actions.schema import ActionStatus
+
+
     class MySection(..., ActionStatus):
         # Assuming quantity `action_instance_id` is already a property of the section.
         # Can be defined in the section or inherited from the parent section.
@@ -269,12 +316,13 @@ class ActionStatus(ArchiveSection):
 
 class Action(ActionStatus, StopAction, StartAction):
     """
-    Base class for actions that can be triggered from the ELN interface. Includes three
+    Base class for actions that can be triggered from the ELN interface. Comes with a
+    normalize method that handles the behavior of the trigger buttons for three
     main functionalities: starting an action, stopping a running action, and retrieving
     the status of an action.
 
-    Subclasses should implement the `start_action` method to define the specific action
-    to be performed.
+    Subclasses should implement the `start_action` method to provide the logic to
+    trigger an action instance.
     """
 
     m_def = Section(
@@ -389,8 +437,11 @@ class Action(ActionStatus, StopAction, StartAction):
 
 class ActionELN(Action, EntryData):
     """
-    Standalone ELN section for running any NOMAD Action that is available in the
-    deployment. Users can trigger the action by specifying the action ID and input data.
+    A general ELN section for running any NOMAD Action available in the deployment.
+    Built on top of the base `Action` class.
+
+    Users can start and monitor an action by specifying the `action_id` and
+    `action_input`.
     """
 
     m_def = Section(

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -21,11 +21,14 @@ from typing import (
 
 from nomad.actions import manager
 from nomad.datamodel import ArchiveSection
+from nomad.datamodel.data import EntryDataCategory
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
     ELNComponentEnum,
+    QuantityDisplayAnnotation,
 )
 from nomad.metainfo import (
+    Category,
     Quantity,
     SchemaPackage,
     Section,
@@ -37,6 +40,32 @@ if TYPE_CHECKING:
 
 
 m_package = SchemaPackage()
+
+
+class ActionCategory(EntryDataCategory):
+    """
+    A category for schemas that can be used to run NOMAD Actions.
+
+    `EntryData` sections with this category will be put under the same group,
+    **"Run NOMAD Actions from ELN"**,
+    in the Create from Schema > Built-in schema dropdown menu.
+
+    Example usage:
+
+    ```python
+    class MyActionELN(Action, EntryData):
+        m_def = Section(
+            description='Section for running my custom action.',
+            categories=[ActionCategory],
+        )
+        ...
+    ```
+    """
+
+    m_def = Category(
+        label='Run NOMAD Actions from ELN',
+        categories=[EntryDataCategory],
+    )
 
 
 class StartAction(ArchiveSection):

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -15,17 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
 from typing import (
     TYPE_CHECKING,
 )
 
 from nomad.actions import manager
-from nomad.datamodel import ArchiveSection
+from nomad.datamodel import ArchiveSection, EntryData
 from nomad.datamodel.data import EntryDataCategory
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
     ELNComponentEnum,
     QuantityDisplayAnnotation,
+    SectionDisplayAnnotation,
 )
 from nomad.metainfo import (
     Category,
@@ -33,6 +35,8 @@ from nomad.metainfo import (
     SchemaPackage,
     Section,
 )
+
+from nomad_analysis.utils import clean_rich_text_to_json
 
 if TYPE_CHECKING:
     from nomad.datamodel import EntryArchive
@@ -380,6 +384,57 @@ class Action(ActionStatus, StopAction, StartAction):
             self.get_action_status(self.action_instance_id, archive, logger)
 
         super().normalize(archive, logger)
+
+
+class ActionELN(Action, EntryData):
+    """
+    Standalone ELN section for running any NOMAD Action that is available in the
+    deployment. Users can trigger the action by specifying the action ID and input data.
+    """
+
+    m_def = Section(
+        description='ELN interface for running a NOMAD Action.',
+        a_display=SectionDisplayAnnotation(
+            order=[
+                'action_id',
+                'action_input',
+                'trigger_start_action',
+                'action_instance_id',
+                'action_status',
+                'trigger_get_action_status',
+                'trigger_stop_action',
+            ]
+        ),
+    )
+
+    action_id = Quantity(
+        type=str,
+        description='The action ID to be triggered. Should be in the format of '
+        '"namespace.package:action_name".',
+        a_eln=ELNAnnotation(component=ELNComponentEnum.StringEditQuantity),
+    )
+
+    action_input = Quantity(
+        type=str,
+        description='The input data for the action. Should be a JSON string that can '
+        'be parsed into the input data model of the given action.',
+        a_eln=ELNAnnotation(component=ELNComponentEnum.RichTextEditQuantity),
+    )
+
+    def start_action(self, archive, logger) -> str:
+        try:
+            clean_input = clean_rich_text_to_json(self.action_input)
+            action_input = json.loads(clean_input)
+            action_input_validated = manager.validate_action_arg(
+                self.action_id, action_input
+            )
+            instance_id = manager.start_action(
+                action_id=self.action_id,
+                data=action_input_validated,
+            )
+            return instance_id
+        except Exception as e:
+            logger.error(f'Failed to start the action: {e}', exc_info=True)
 
 
 m_package.__init_metainfo__()

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -374,6 +374,7 @@ class Action(ActionStatus, StopAction, StartAction):
             else:
                 try:
                     self.action_instance_id = self.start_action(archive, logger)
+                    self.action_status = None
                     self.trigger_get_action_status = True
                 except Exception:
                     logger.warning('Failed to start the action.', exc_info=True)

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 import json
+from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
 )
@@ -122,6 +123,7 @@ class StartAction(ArchiveSection):
         ),
     )
 
+    @abstractmethod
     def start_action(self, archive, logger) -> str:
         """
         Provides the logic to trigger an action instance. To be implemented by
@@ -330,6 +332,7 @@ class Action(ActionStatus, StopAction, StartAction):
         categories=[ActionCategory],
     )
 
+    @abstractmethod
     def start_action(self, archive, logger):
         """
         To be implemented by subclasses. Based on the data available in the ELN,

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -356,7 +356,7 @@ class Action(ActionStatus, StopAction, StartAction):
         if self.trigger_stop_action:
             if self.action_status != 'RUNNING':
                 self.trigger_stop_action = False
-                logger.error(
+                logger.warning(
                     'The action is not running. Cannot stop an action that '
                     'is not running.'
                 )
@@ -367,7 +367,7 @@ class Action(ActionStatus, StopAction, StartAction):
         if self.trigger_start_action:
             if self.action_status == 'RUNNING':
                 self.trigger_start_action = False
-                logger.error(
+                logger.warning(
                     'The action is already running. Please wait for it to '
                     'complete before running the action again.'
                 )
@@ -376,7 +376,7 @@ class Action(ActionStatus, StopAction, StartAction):
                     self.action_instance_id = self.start_action(archive, logger)
                     self.trigger_get_action_status = True
                 except Exception:
-                    logger.error('Failed to start the action.', exc_info=True)
+                    logger.warning('Failed to start the action.', exc_info=True)
                 finally:
                     self.trigger_start_action = False
 

--- a/src/nomad_analysis/actions/schema.py
+++ b/src/nomad_analysis/actions/schema.py
@@ -39,6 +39,202 @@ if TYPE_CHECKING:
 m_package = SchemaPackage()
 
 
+class StartAction(ArchiveSection):
+    """Section to trigger an action instance."""
+
+    action_instance_id = Quantity(
+        type=str,
+        description='Instance ID of the action.',
+        a_eln=ELNAnnotation(component=ELNComponentEnum.StringEditQuantity),
+        a_display=QuantityDisplayAnnotation(editable=False, visible=True),
+    )
+    trigger_start_action = Quantity(
+        type=bool,
+        default=False,
+        description='Starts the action defined under `start_action` method.',
+        a_eln=ELNAnnotation(
+            component=ELNComponentEnum.ActionEditQuantity, label='Start Action'
+        ),
+    )
+
+    def start_action(self, archive, logger) -> str:
+        """
+        To be implemented by subclasses. Based on the data available in the ELN,
+        use this method to prepare the input for the given action and trigger it using
+        `nomad.actions.manager.start_action`.
+
+        The method should return the same instance ID of the triggered action as
+        returned by the `nomad.actions.manager.start_action` method.
+
+        Example implementation:
+
+        ```python
+        from nomad.actions import manager
+
+        def start_action(self, archive, logger) -> str:
+            # Prepare input for the action
+            action_input = MyActionInput(
+                user_id=archive.metadata.authors[0].user_id,
+                upload_id=archive.metadata.upload_id,
+                # other necessary input data for the action
+            )
+
+            # Start the action using the NOMAD action manager
+            instance_id = manager.start_action(
+                action_id='nomad_example.actions.myaction:my_action',
+                data=action_input,
+            )
+
+            return instance_id
+        ```
+
+        When using an implemented `start_action` method, condition it on the
+        `trigger_start_action` quantity to ensure that the action is triggered when the
+        quantity is set to True. And set the trigger quantity to False the method
+        is executed to avoid retriggering the action on the next normalization.
+
+        Returns:
+            str: The instance ID of the triggered action.
+        """
+        raise NotImplementedError('Subclasses should implement this method.')
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+        """
+        Normalizes the action entry. If `trigger_start_action` is set to True, it calls
+        the `start_action` method to execute the action and sets
+        `trigger_get_action_status` to True to retrieve the action status. If
+        `trigger_get_action_status` is set to True, it calls the `_get_action_status`
+        method to update the `action_status`.
+
+        Args:
+            archive (Archive): A NOMAD archive.
+            logger (Logger): A structured logger.
+        """
+        if self.trigger_start_action:
+            try:
+                self.action_instance_id = self.start_action(archive, logger)
+            except Exception:
+                logger.warning('Failed to start the action.', exc_info=True)
+            finally:
+                self.trigger_start_action = False
+
+        super().normalize(archive, logger)
+
+
+class StopAction(ArchiveSection):
+    """
+    Section to stop a running action instance. Comes with a method `stop_action` that
+    takes in action instance ID and schedules a cancellation of the action. It can used
+    in the `normalize` method of child sections and set to be triggered using the
+    `trigger_stop_action` quantity.
+
+    Example usage:
+    ```python
+    class MyActionELN(..., StopAction):
+        # Assuming quantity `action_instance_id` is already a property of the section.
+        # Can be defined in the section or inherited from the parent section.
+
+        def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+            super().normalize(archive, logger)
+
+            # Other normalization code...
+
+            if self.trigger_stop_action:
+                self.stop_action(self.action_instance_id, archive, logger)
+    ```
+    """
+
+    trigger_stop_action = Quantity(
+        type=bool,
+        default=False,
+        description='Schedule a cancellation of the action associated with the '
+        'action instance ID.',
+        a_eln=ELNAnnotation(
+            component=ELNComponentEnum.ActionEditQuantity, label='Stop Action'
+        ),
+    )
+
+    def stop_action(
+        self, action_instance_id: str, archive: 'EntryArchive', logger: 'BoundLogger'
+    ):
+        """
+        Schedule a cancellation of the action associated with the action instance ID.
+        """
+        try:
+            if not action_instance_id:
+                raise ValueError('No action ID found.')
+            manager.stop_action(action_instance_id, archive.metadata.authors[0].user_id)
+            logger.info(
+                f'Action with instance ID {action_instance_id} has been '
+                'scheduled for stopping.'
+            )
+        except Exception:
+            logger.warning('Failed to stop the action.', exc_info=True)
+        finally:
+            self.trigger_stop_action = False
+
+
+class ActionStatus(ArchiveSection):
+    """
+    Section to save and fetch the status of an action instance. Comes with a method
+    `get_action_status` that takes in action instance ID and gets the status. It can
+    used in the `normalize` method of child sections and set to be triggered using
+    the `trigger_get_action_status` quantity.
+
+    Example usage:
+
+    ```python
+    class MySection(..., ActionStatus):
+        # Assuming quantity `action_instance_id` is already a property of the section.
+        # Can be defined in the section or inherited from the parent section.
+
+        def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+            super().normalize(archive, logger)
+
+            # Other normalization code...
+
+            if self.trigger_get_action_status:
+                self.get_action_status(self.action_instance_id, archive, logger)
+    ```
+    """
+
+    action_status = Quantity(
+        type=str,
+        description='Status of the action instance.',
+        a_eln=ELNAnnotation(component=ELNComponentEnum.StringEditQuantity),
+        a_display=QuantityDisplayAnnotation(editable=False, visible=True),
+    )
+    trigger_get_action_status = Quantity(
+        type=bool,
+        default=False,
+        description='Retrieves the status of the action using action ID.',
+        a_eln=ELNAnnotation(
+            component=ELNComponentEnum.ActionEditQuantity, label='Get Action Status'
+        ),
+    )
+
+    def get_action_status(
+        self, action_instance_id: str, archive: 'EntryArchive', logger: 'BoundLogger'
+    ):
+        """
+        Retrieves the status of the action using the `action_instance_id`.
+        """
+        status = None
+        try:
+            if not action_instance_id:
+                raise ValueError('No action instance ID found.')
+            status = manager.get_action_status(
+                action_instance_id, archive.metadata.authors[0].user_id
+            )
+        except Exception:
+            logger.warning('Failed to get action status.', exc_info=True)
+        finally:
+            if status is not None:
+                self.action_status = status.name
+            self.trigger_get_action_status = False
+
+
+
 class Action(ArchiveSection):
     """
     Base class for triggering actions from the ELN interface.

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -21,11 +21,9 @@
 Utility functions for the analysis plugin.
 """
 
-import html
 import importlib
 import inspect
 import json
-import re
 from typing import TYPE_CHECKING, Any
 
 import requests

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -257,32 +257,3 @@ def put_nomad_request(
         raise ValueError(f'Unexpected response {response.json()}')
 
     return response.json()
-
-
-def clean_rich_text_to_json(rich_text: str) -> str:
-    """
-    Converts HTML-formatted rich text to a plain string suitable for JSON parsing.
-
-    Handles common HTML elements from RichTextEditQuantity:
-    - Removes HTML tags (<p>, <br />, etc.)
-    - Decodes HTML entities (&nbsp;, &amp;, &quot;, etc.) into unicode characters
-    - Converts non-breaking spaces to regular spaces
-
-    Args:
-        rich_text: HTML-formatted string from RichTextEditQuantity.
-
-    Returns:
-        Plain text string that can be parsed by json.loads().
-    """
-    if not rich_text:
-        return ''
-
-    clean = re.sub(r'<[^>]+>', '', rich_text)
-
-    # Decode HTML entities (&nbsp; -> \xa0, &amp; -> &, etc.)
-    clean = html.unescape(clean)
-
-    # Replace non-breaking spaces (\xa0) with regular spaces
-    clean = clean.replace('\xa0', ' ')
-
-    return clean.strip()

--- a/src/nomad_analysis/utils.py
+++ b/src/nomad_analysis/utils.py
@@ -21,9 +21,11 @@
 Utility functions for the analysis plugin.
 """
 
+import html
 import importlib
 import inspect
 import json
+import re
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -255,3 +257,32 @@ def put_nomad_request(
         raise ValueError(f'Unexpected response {response.json()}')
 
     return response.json()
+
+
+def clean_rich_text_to_json(rich_text: str) -> str:
+    """
+    Converts HTML-formatted rich text to a plain string suitable for JSON parsing.
+
+    Handles common HTML elements from RichTextEditQuantity:
+    - Removes HTML tags (<p>, <br />, etc.)
+    - Decodes HTML entities (&nbsp;, &amp;, &quot;, etc.) into unicode characters
+    - Converts non-breaking spaces to regular spaces
+
+    Args:
+        rich_text: HTML-formatted string from RichTextEditQuantity.
+
+    Returns:
+        Plain text string that can be parsed by json.loads().
+    """
+    if not rich_text:
+        return ''
+
+    clean = re.sub(r'<[^>]+>', '', rich_text)
+
+    # Decode HTML entities (&nbsp; -> \xa0, &amp; -> &, etc.)
+    clean = html.unescape(clean)
+
+    # Replace non-breaking spaces (\xa0) with regular spaces
+    clean = clean.replace('\xa0', ' ')
+
+    return clean.strip()


### PR DESCRIPTION
- Splits the functionality of `Action` schema into three schema for modularity: `StartAction`, `StopAction`, `ActionStatus`.
- Adds `ActionCategory`